### PR TITLE
fix: change base image as official node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM spearheadea/tsnode:8.9.4-slim-2.1.4
+FROM node:latest
 
 WORKDIR /app
 COPY package.json /app/


### PR DESCRIPTION
Change base image as official node image.
There is no reason to use custom base image like tsnode anymore.