### PR TITLE
Added istanbul option, includeUntested => true

### DIFF
--- a/tasks/coverage.js
+++ b/tasks/coverage.js
@@ -7,7 +7,9 @@ module.exports = function (options) {
 
   function preIstanbulTask() {
     return gulp.src(['dist/**/*.js', '!dist/spec/**/*.js'])
-      .pipe(istanbul())
+      .pipe(istanbul({
+        includeUntested: true
+      }))
       .pipe(istanbul.hookRequire());
   }
 


### PR DESCRIPTION
Shows actual coverage of all files regardless of spec file

 On branch fix.coverage.untestedFiles
 Changes to be committed:
	modified:   tasks/coverage.js

http://git.sphd.io/support/stt-issues/issues/3613